### PR TITLE
Add Rubocop file for consistent styling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
       run: gem install rubocop
 
     - name: Run Rubocop
-      run: rubocop
+      # Only run Rubocop on changed files
+      run: git diff -r --name-only origin/master | grep '\.rb$' | xargs -r rubocop
       # Allow Rubocop to run without breaking the workflow
       continue-on-error: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
       run: gem install rubocop
 
     - name: Run Rubocop
-      # Only run Rubocop on changed files
-      run: git diff -r --name-only ${{ github.event.pull_request.base.sha }} | grep '\.rb$' | xargs -r rubocop
       # Allow Rubocop to run without breaking the workflow
       continue-on-error: true
+      # Only run Rubocop on changed files
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.sha }}
+        git diff -r --name-only ${{ github.event.pull_request.base.sha }} | grep '\.rb$' | xargs -r rubocop
 
   rspec-test:
     name: Rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   rubocop-lint:
     name: Rubocop
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -31,7 +32,7 @@ jobs:
 
     - name: Run Rubocop
       # Only run Rubocop on changed files
-      run: git diff -r --name-only origin/master | grep '\.rb$' | xargs -r rubocop
+      run: git diff -r --name-only ${{ github.event.pull_request.base.sha }} | grep '\.rb$' | xargs -r rubocop
       # Allow Rubocop to run without breaking the workflow
       continue-on-error: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,7 +45,10 @@ Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  SafeAutoCorrect: true
+  Details: 'Add `# frozen_string_literal: true` to the top of the file. Frozen string
+    literals will become the default in a future Ruby version, and we want to make
+    sure we''re ready.'
 
 Style/Documentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,21 +28,17 @@ Metrics/MethodLength:
 
 # The guiding principle of classes is SRP, SRP can't be accurately measured by LoC
 Metrics/ClassLength:
-  Max: 1500
+  Max: 500
 
 # We don't need screaming snake case all the damn time
 Naming/ConstantName:
   Enabled: false
 
-# Single quotes being faster is hardly measurable and only affects parse time.
-# Enforcing double quotes reduces the times where you need to change them
-# when introducing an interpolation. Use single quotes only if their semantics
-# are needed.
 Style/StringLiterals:
-  EnforcedStyle: double_quotes
+  Enabled: false
 
 Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   SafeAutoCorrect: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,57 @@
+# The behavior of RuboCop can be controlled via the .rubocop.yml
+# configuration file. It makes it possible to enable/disable
+# certain cops (checks) and to alter their behavior if they accept
+# any parameters. The file can be placed either in your home
+# directory or in some project directory.
+#
+# RuboCop will start looking for the configuration file in the directory
+# where the inspected file is and continue its way up to the root directory.
+#
+# See https://docs.rubocop.org/rubocop/configuration
+Layout/LineLength:
+  Max: 120
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+# Too short methods lead to extraction of single-use methods, which can make
+# the code easier to read (by naming things), but can also clutter the class
+Metrics/MethodLength: 
+  Max: 20
+
+# The guiding principle of classes is SRP, SRP can't be accurately measured by LoC
+Metrics/ClassLength:
+  Max: 1500
+
+# We don't need screaming snake case all the damn time
+Naming/ConstantName:
+  Enabled: false
+
+# Single quotes being faster is hardly measurable and only affects parse time.
+# Enforcing double quotes reduces the times where you need to change them
+# when introducing an interpolation. Use single quotes only if their semantics
+# are needed.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma


### PR DESCRIPTION
# What

This pull request adds a **.rubocop.yml** file to the repository, so that we can have consistent styling. Additionally, it only runs Rubocop against a pull request since these syntax errors should be caught at the PR stage.

## Misc

It'd be nice to start updating the rest of the `happy-software` Ruby repos to use the same Rubocop settings. We can even
have a main repo that has our preferred styles/configurations, which we can all contribute to.
