### PR TITLE
Run CI/CD when a PR is open or a push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,13 @@
 name: Ruby CI
 
 # Trigger the workflow on push or pull request
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs: 
   rubocop-lint:


### PR DESCRIPTION
This commit updates the CI/CD workflow to not run the same Github actions twice per commit. We now only run the actions on an open PR (where the target branch is master), or when a push to master.

## Misc

We used to run each job in `.github/workflows/ci.yml` twice:

![image](https://user-images.githubusercontent.com/1649281/164913338-82b59faa-77ca-4d7f-8620-46bd70c1167c.png)
