### PR TITLE
Load 7.2 defaults

### DIFF
--- a/app/models/playlist_snapshot.rb
+++ b/app/models/playlist_snapshot.rb
@@ -1,5 +1,4 @@
 require 'yt'
-require 'playlist_difference_calculator'
 require 'youtube_watcher/slacker'
 
 class PlaylistSnapshot < ApplicationRecord

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ Bundler.require(*Rails.groups)
 module YoutubeWatcher
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.2
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/spec/services/playlist_difference_calculator_spec.rb
+++ b/spec/services/playlist_difference_calculator_spec.rb
@@ -1,4 +1,4 @@
-require 'playlist_difference_calculator'
+require 'spec_helper'
 
 RSpec.describe PlaylistDifferenceCalculator do
   describe '.calculate_diffs' do

--- a/spec/services/playlist_difference_renderer_spec.rb
+++ b/spec/services/playlist_difference_renderer_spec.rb
@@ -1,4 +1,5 @@
-require 'playlist_difference_renderer'
+# require 'playlist_difference_renderer'
+require 'spec_helper'
 
 RSpec.describe PlaylistDifferenceRenderer do
   let(:playlist_id)   { 'some-playlist-id' }


### PR DESCRIPTION
Had an issue wih SYT not loading and getting 503 errors from the prod back end while upgrading to 7.2.
This doesn't happen in local so I'm not sure what is causing the issue.
Gonna try bumping the defaults to 7.2 to see if that changes anything.