### PR TITLE
Rollback Rails 7.2 Gemfile and Gemfile.lock updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,4 +65,14 @@ gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem "dockerfile-rails", ">= 1.6", :group => :development
 
+# For views
 gem "slim-rails", "~> 3.6"
+
+# Error tracking
+gem "honeybadger", "~> 5.15"
+
+# Background jobs
+gem 'sidekiq'
+gem 'sidekiq-cron'
+
+gem "redis", "~> 5.2"

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,10 @@ gem 'slack-ruby-client'
 gem 'chartkick'
 gem 'groupdate'
 
+gem 'sentry-raven'
+gem 'sentry-ruby'
+gem 'sentry-rails'
+
 # Ruby 3.1+ needs the net-smtp gem explicitly required
 # https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp/70500221#70500221
 gem 'net-smtp', require: false
@@ -61,14 +65,4 @@ gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem "dockerfile-rails", ">= 1.6", :group => :development
 
-# For views
 gem "slim-rails", "~> 3.6"
-
-# Error tracking
-gem "honeybadger", "~> 5.15"
-
-# Background jobs
-gem 'sidekiq'
-gem 'sidekiq-cron'
-
-gem "redis", "~> 5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.1)
+    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.0)
@@ -85,6 +86,8 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.12.0)
+    et-orbi (1.2.11)
+      tzinfo
     execjs (2.8.1)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
@@ -96,12 +99,16 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     gli (2.21.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     groupdate (6.2.0)
       activesupport (>= 5.2)
     hashie (5.0.0)
+    honeybadger (5.15.6)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -110,6 +117,7 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -148,6 +156,7 @@ GEM
       pry (>= 0.10.4)
     puma (5.6.8)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.0)
     rack (2.2.9)
     rack-cors (2.0.0)
@@ -186,6 +195,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -225,6 +238,16 @@ GEM
       faraday (>= 1.0)
     sentry-ruby (5.8.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sidekiq (7.3.1)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
+    sidekiq-cron (1.12.0)
+      fugit (~> 1.8)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6)
     slack-ruby-client (2.0.0)
       faraday (>= 2.0)
       faraday-mashify
@@ -285,6 +308,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.6)
   dotenv-rails
   groupdate
+  honeybadger (~> 5.15)
   jbuilder (~> 2.10)
   listen (>= 3.0.5, < 3.2)
   net-imap
@@ -295,12 +319,15 @@ DEPENDENCIES
   puma (~> 5.6.8)
   rack-cors
   rails (~> 6.1)
+  redis (~> 5.2)
   rspec
   rspec-rails (~> 4.0.0)
   sass-rails (~> 6.0.0)
   sentry-rails
   sentry-raven
   sentry-ruby
+  sidekiq
+  sidekiq-cron
   slack-ruby-client
   slim-rails (~> 3.6)
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,11 +61,11 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     bindex (0.8.1)
-    bootsnap (1.18.4)
+    bootsnap (1.16.0)
       msgpack (~> 1.2)
-    builder (3.3.0)
+    builder (3.2.4)
     byebug (11.1.3)
-    chartkick (5.1.0)
+    chartkick (5.0.1)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -74,51 +74,42 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.1)
     crass (1.0.6)
     date (3.3.4)
-    diff-lcs (1.5.1)
+    diff-lcs (1.5.0)
     dockerfile-rails (1.6.17)
       rails (>= 3.0.0)
-    dotenv (3.1.2)
-    dotenv-rails (3.1.2)
-      dotenv (= 3.1.2)
-      railties (>= 6.1)
-    erubi (1.13.0)
-    et-orbi (1.2.11)
-      tzinfo
-    execjs (2.9.1)
-    faraday (2.10.1)
-      faraday-net_http (>= 2.0, < 3.2)
-      logger
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
+    erubi (1.12.0)
+    execjs (2.8.1)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
     faraday-mashify (0.1.1)
       faraday (~> 2.0)
       hashie
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
-    faraday-net_http (3.1.1)
-      net-http
-    ffi (1.17.0)
-    fugit (1.11.1)
-      et-orbi (~> 1, >= 1.2.11)
-      raabro (~> 1.4)
-    gli (2.21.5)
+    faraday-net_http (3.0.2)
+    ffi (1.15.5)
+    gli (2.21.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    groupdate (6.4.0)
-      activesupport (>= 6.1)
+    groupdate (6.2.0)
+      activesupport (>= 5.2)
     hashie (5.0.0)
-    honeybadger (5.15.6)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    jbuilder (2.12.0)
+    jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -127,40 +118,39 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.4)
-    method_source (1.1.0)
+    marcel (1.0.2)
+    method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.25.1)
-    msgpack (1.7.2)
-    multipart-post (2.4.1)
-    net-http (0.4.1)
-      uri
-    net-imap (0.4.14)
+    minitest (5.23.1)
+    msgpack (1.6.0)
+    multipart-post (2.3.0)
+    net-imap (0.3.4)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.3.3)
       net-protocol
-    nio4r (2.7.3)
-    nokogiri (1.16.7)
+    nio4r (2.7.0)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    pg (1.5.7)
+    nokogiri (1.16.5-x86_64-linux)
+      racc (~> 1.4)
+    pg (1.4.6)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-rails (0.3.11)
-      pry (>= 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (5.6.8)
       nio4r (~> 2.0)
-    raabro (1.4.0)
-    racc (1.8.1)
+    racc (1.8.0)
     rack (2.2.9)
-    rack-cors (2.0.2)
+    rack-cors (2.0.0)
       rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -192,26 +182,22 @@ GEM
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
-    rake (13.2.1)
+    rake (13.1.0)
     rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.3.0)
-      redis-client (>= 0.22.0)
-    redis-client (0.22.2)
-      connection_pool
-    rspec (3.13.0)
-      rspec-core (~> 3.13.0)
-      rspec-expectations (~> 3.13.0)
-      rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
-      rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.2)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
+      rspec-support (~> 3.12.0)
     rspec-rails (4.0.2)
       actionpack (>= 4.2)
       activesupport (>= 4.2)
@@ -220,7 +206,8 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
-    rspec-support (3.13.1)
+    rspec-support (3.12.0)
+    ruby2_keywords (0.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -231,22 +218,20 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sidekiq (7.3.1)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      logger
-      rack (>= 2.2.4)
-      redis-client (>= 0.22.2)
-    sidekiq-cron (1.12.0)
-      fugit (~> 1.8)
-      globalid (>= 1.0.1)
-      sidekiq (>= 6)
-    slack-ruby-client (2.4.0)
+    sentry-rails (5.8.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.8.0)
+    sentry-raven (3.1.2)
+      faraday (>= 1.0)
+    sentry-ruby (5.8.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+    slack-ruby-client (2.0.0)
       faraday (>= 2.0)
       faraday-mashify
       faraday-multipart
       gli
       hashie
+      websocket-driver
     slim (5.2.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
@@ -261,13 +246,13 @@ GEM
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.5.2)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     temple (0.10.3)
     thor (1.3.1)
-    tilt (2.4.0)
+    tilt (2.1.0)
     timeout (0.4.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -276,8 +261,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    uri (0.13.0)
-    web-console (4.2.1)
+    web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
@@ -287,10 +271,11 @@ GEM
     websocket-extensions (0.1.5)
     yt (0.33.4)
       activesupport
-    zeitwerk (2.6.17)
+    zeitwerk (2.6.15)
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
@@ -300,7 +285,6 @@ DEPENDENCIES
   dockerfile-rails (>= 1.6)
   dotenv-rails
   groupdate
-  honeybadger (~> 5.15)
   jbuilder (~> 2.10)
   listen (>= 3.0.5, < 3.2)
   net-imap
@@ -311,12 +295,12 @@ DEPENDENCIES
   puma (~> 5.6.8)
   rack-cors
   rails (~> 6.1)
-  redis (~> 5.2)
   rspec
   rspec-rails (~> 4.0.0)
   sass-rails (~> 6.0.0)
-  sidekiq
-  sidekiq-cron
+  sentry-rails
+  sentry-raven
+  sentry-ruby
   slack-ruby-client
   slim-rails (~> 3.6)
   spring
@@ -331,4 +315,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.4.6
+   2.3.13


### PR DESCRIPTION
Rollback Rails 7.2 Gemfile and Gemfile.lock updates from PR: https://github.com/happy-software/happy_youtube_watcher/pull/89 since it started causing syt to break with CORS errors; trying to manually bisect where the failure happens