### PR TITLE
Store a `PlaylistDelta` each time we take a snapshot

### DIFF
--- a/app/models/playlist_delta.rb
+++ b/app/models/playlist_delta.rb
@@ -1,0 +1,8 @@
+class PlaylistDelta < ApplicationRecord
+  belongs_to :playlist_snapshot
+  belongs_to :tracked_playlist
+
+  def change_datetime
+    playlist_snapshot.created_at
+  end
+end

--- a/db/migrate/20241107022348_create_playlist_delta.rb
+++ b/db/migrate/20241107022348_create_playlist_delta.rb
@@ -1,0 +1,12 @@
+class CreatePlaylistDelta < ActiveRecord::Migration[6.1]
+  def change
+    create_table :playlist_delta do |t|
+      t.references :tracked_playlist, null: false, foreign_key: true, index: true
+      t.references :playlist_snapshot, null: false, foreign_key: true, index: true
+      t.jsonb :added, default: {}, null: false
+      t.jsonb :removed, default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_16_224501) do
+ActiveRecord::Schema.define(version: 2024_11_07_022348) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
+
+  create_table "playlist_delta", force: :cascade do |t|
+    t.bigint "tracked_playlist_id", null: false
+    t.bigint "playlist_snapshot_id", null: false
+    t.jsonb "added", default: {}, null: false
+    t.jsonb "removed", default: {}, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["playlist_snapshot_id"], name: "index_playlist_delta_on_playlist_snapshot_id"
+    t.index ["tracked_playlist_id"], name: "index_playlist_delta_on_tracked_playlist_id"
+  end
+
+  create_table "playlist_items", id: false, force: :cascade do |t|
+    t.integer "id", null: false
+    t.integer "playlist_snapshot_id"
+  end
 
   create_table "playlist_settings", force: :cascade do |t|
     t.string "playlist_id"
@@ -30,28 +47,6 @@ ActiveRecord::Schema.define(version: 2023_07_16_224501) do
     t.index ["playlist_id"], name: "index_playlist_snapshots_on_playlist_id"
   end
 
-  create_table "playlists", force: :cascade do |t|
-    t.string "channel_username"
-    t.string "channel_id"
-    t.string "youtube_id"
-    t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["youtube_id"], name: "index_playlists_on_youtube_id", unique: true
-  end
-
-  create_table "songs", force: :cascade do |t|
-    t.string "video_id"
-    t.string "title"
-    t.string "uploader"
-    t.datetime "video_uploaded_date"
-    t.jsonb "description"
-    t.string "playlist_id"
-    t.string "playlist_index"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "tracked_playlists", force: :cascade do |t|
     t.string "playlist_id"
     t.datetime "created_at", null: false
@@ -66,4 +61,6 @@ ActiveRecord::Schema.define(version: 2023_07_16_224501) do
     t.index ["playlist_id"], name: "index_tracked_playlists_on_playlist_id", unique: true
   end
 
+  add_foreign_key "playlist_delta", "playlist_snapshots"
+  add_foreign_key "playlist_delta", "tracked_playlists"
 end

--- a/spec/models/playlist_snapshot_spec.rb
+++ b/spec/models/playlist_snapshot_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe PlaylistSnapshot do
       allow(PlaylistDifferenceRenderer).to receive(:post_diff)
     end
 
-    after do
-      TrackedPlaylist.all.each(&:destroy)
-      PlaylistSnapshot.all.each(&:destroy)
-    end
-
     let(:mocked_yt_response) do
       {
         'song_1' => {'title'=>'song_1_title',


### PR DESCRIPTION
Every time a new snapshot is taken, that means there was a diff in the playlist.
So let's store that delta in a `PlaylistDelta` model so that we can display the playlist history timeline from it instead of recomputing it each time.