### PR TITLE
Keep player controls in mobile view always regardless of focus mode being on or off

### DIFF
--- a/app/assets/stylesheets/_responsive.scss
+++ b/app/assets/stylesheets/_responsive.scss
@@ -123,8 +123,8 @@ form button {
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 50%;
-  width: 3rem;
-  height: 3rem;
+  width: 4rem;
+  height: 4rem;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -62,7 +62,9 @@ export default class extends Controller {
       if (this.hasFocusToggleTarget) { this.focusToggleTarget.textContent = "Exit Focus Mode" }
     } else {
       this.element.classList.remove("focus-mode");
-      this.focusControlsTarget.classList.add("hidden");
+      if (window.innerWidth > 768) {
+        this.focusControlsTarget.classList.add("hidden");
+      }
 
       if (this.hasFocusToggleTarget) { this.focusToggleTarget.textContent = "Enter Focus Mode" }
     }


### PR DESCRIPTION
Also, make the buttons slightly larger to make them easier to press