### PR TITLE
Fix Ahoy Event Track - Add Warden to ignore list

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   end
 
   def track_event
-    headers = request.headers.to_h.reject { |k,v| ['puma', 'action_dispatch', 'honeybadger', 'rack', 'action_controller'].any? { |word| k.to_s.downcase.include?(word) } }
+    headers = request.headers.to_h.reject { |k,v| ['warden', 'puma', 'action_dispatch', 'honeybadger', 'rack', 'action_controller'].any? { |word| k.to_s.downcase.include?(word) } }
     ahoy.track action_name, current_user_id: current_user&.id, **request.path_parameters, **headers
   end
 end


### PR DESCRIPTION
Objects in headers cause `.to_json` to get called recursively and blow up with a stack level too deep error.