### PR TITLE
Nudge user to add playlist when filter has no results (#238)

### DIFF
--- a/app/assets/stylesheets/manage_playlists_page.scss
+++ b/app/assets/stylesheets/manage_playlists_page.scss
@@ -141,6 +141,20 @@
     }
   }
 
+  .no-filter-results {
+    text-align: center;
+    padding: 2rem 1rem;
+    background: #f0f7ff;
+    border: 1px dashed #c7dff7;
+    border-radius: 0.75rem;
+    margin-bottom: 1rem;
+
+    p {
+      margin: 0 0 1rem 0;
+      color: #1a4f8a;
+    }
+  }
+
   .form-hint {
     font-size: 0.8rem;
     color: #666;

--- a/app/javascript/controllers/favorites_controller.js
+++ b/app/javascript/controllers/favorites_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["list"];
+  static targets = ["list", "noResults"];
 
   connect() {
     this.savePlaylistSelectionLocally = this.savePlaylistSelectionLocally.bind(this);
@@ -41,5 +41,10 @@ export default class extends Controller {
       const matches = name.includes(query) || playlistId.includes(query)
       item.style.display = matches ? "" : "none";
     })
+
+    if (this.hasNoResultsTarget) {
+      const anyVisible = Array.from(items).some(item => item.style.display !== "none");
+      this.noResultsTarget.classList.toggle("hidden", anyVisible);
+    }
   }
 }

--- a/app/views/favorite_playlists/index.html.slim
+++ b/app/views/favorite_playlists/index.html.slim
@@ -9,6 +9,9 @@ div.playlists-page data-controller="add-playlist-modal favorites" data-add-playl
   / List of playlists
   div.playlist-list[data-favorites-target="list"]
     - if @playlists.any?
+      div.no-filter-results.hidden data-favorites-target="noResults"
+        p No playlists match your search.
+        button.add-playlist-btn data-action="click->add-playlist-modal#open" + Add Playlist
       - @playlists.each do |playlist|
         div.playlist-card data-playlist-id=playlist.id data-name=playlist.name
           div.info


### PR DESCRIPTION
## What & why

Closes #238.

When a user filters their favorite playlists and nothing matches, the list previously just went blank — a common first-time failure mode where someone searches for a playlist they haven't added yet and gets stuck with no path forward.

This adds an inline "no results" nudge that appears only when the filter hides every card, with a one-click button to open the existing Add Playlist modal.

## Changes

- **`app/views/favorite_playlists/index.html.slim`** — Added a hidden `.no-filter-results` block (Stimulus target `noResults`) at the top of the playlist list. Its "+ Add Playlist" button reuses the existing `add-playlist-modal#open` action.
- **`app/javascript/controllers/favorites_controller.js`** — Registered the `noResults` target and, at the end of `filterList`, toggle the nudge based on whether any card is still visible. Guarded with `hasNoResultsTarget` so the zero-playlists "Welcome" state is unaffected.
- **`app/assets/stylesheets/manage_playlists_page.scss`** — Added a `.no-filter-results` style matching the existing `.getting-started` callout aesthetic (light-blue, centered).

## Behavior

- Filter matches nothing → nudge appears with a way to add the playlist.
- Clear the query or type a matching term → nudge hides again.
- User with zero favorites still sees the existing "Welcome!" getting-started card (unchanged).

## Notes

- Pure frontend; no backend, routes, or DB changes.
- Draft — the nudge copy ("No playlists match your search.") and styling are easy to tweak; open to adjusting placement (currently top of list vs. centered in the empty space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoCX2LPmSknuaGEn83duti

---
_Generated by [Claude Code](https://claude.ai/code/session_01WoCX2LPmSknuaGEn83duti)_